### PR TITLE
Strict validation

### DIFF
--- a/lib/hash_validator/base.rb
+++ b/lib/hash_validator/base.rb
@@ -6,7 +6,7 @@ class HashValidator::Base
     self.errors      = {}
     self.hash        = hash
     self.validations = validations
-
+    
     validate
   end
 
@@ -14,12 +14,16 @@ class HashValidator::Base
     errors.empty?
   end
 
-  def self.validate(hash, validations)
+  def self.validate(hash, validations, strict = false)
+    @strict = strict
     new(hash, validations)
   end
-
-
-private
+  
+  def self.strict?
+    @strict
+  end
+  
+  private
   def validate
     HashValidator.validator_for(hash).validate(:base, self.hash, self.validations, self.errors)
     self.errors = errors[:base]

--- a/lib/hash_validator/validators/hash_validator.rb
+++ b/lib/hash_validator/validators/hash_validator.rb
@@ -20,6 +20,12 @@ class HashValidator::Validator::HashValidator < HashValidator::Validator::Base
     validations.each do |v_key, v_value|
       HashValidator.validator_for(v_value).validate(v_key, value[v_key], v_value, errors)
     end
+    
+    if HashValidator::Base.strict?
+      value.keys.each do |k|
+        errors[k] = 'key not expected' unless validations[k]
+      end
+    end
 
     # Cleanup errors (remove any empty nested errors)
     errors.delete_if { |k,v| v.empty? }

--- a/spec/hash_validator_spec.rb
+++ b/spec/hash_validator_spec.rb
@@ -28,46 +28,46 @@ describe HashValidator do
   describe '#validate' do
     describe 'individual type validations' do
       it 'should validate hash' do
-        validate({ v: {} }, { v: {} }).valid?.should be_true
+        expect(validate({ v: {} }, { v: {} }).valid?).to eq true
 
-        validate({ v: '' }, { v: {} }).valid?.should be_false
-        validate({ v: '' }, { v: {} }).errors.should eq({ v: 'hash required' })
+        expect(validate({ v: '' }, { v: {} }).valid?).to eq false
+        expect(validate({ v: '' }, { v: {} }).errors).to eq({ v: 'hash required' })
       end
 
       it 'should validate presence' do
-        validate({ v: 'test' }, { v: 'required' }).valid?.should be_true
-        validate({ v: 1234   }, { v: 'required' }).valid?.should be_true
+        expect(validate({ v: 'test' }, { v: 'required' }).valid?).to eq true
+        expect(validate({ v: 1234   }, { v: 'required' }).valid?).to eq true
 
-        validate({ v: nil    }, { v: 'required' }).valid?.should be_false
-        validate({ v: nil    }, { v: 'required' }).errors.should eq({ v: 'is required' })
+        expect(validate({ v: nil    }, { v: 'required' }).valid?).to eq false
+        expect(validate({ v: nil    }, { v: 'required' }).errors).to eq({ v: 'is required' })
 
-        validate({ x: 'test' }, { v: 'required' }).valid?.should be_false
-        validate({ x: 'test' }, { v: 'required' }).errors.should eq({ v: 'is required' })
+        expect(validate({ x: 'test' }, { v: 'required' }).valid?).to eq false
+        expect(validate({ x: 'test' }, { v: 'required' }).errors).to eq({ v: 'is required' })
 
-        validate({ x: 1234   }, { v: 'required' }).valid?.should be_false
-        validate({ x: 1234   }, { v: 'required' }).errors.should eq({ v: 'is required' })
+        expect(validate({ x: 1234   }, { v: 'required' }).valid?).to eq false
+        expect(validate({ x: 1234   }, { v: 'required' }).errors).to eq({ v: 'is required' })
       end
 
       it 'should validate string' do
-        validate({ v: 'test' }, { v: 'string' }).valid?.should be_true
+        expect(validate({ v: 'test' }, { v: 'string' }).valid?).to eq true
 
-        validate({ v: 123456 }, { v: 'string' }).valid?.should be_false
-        validate({ v: 123456 }, { v: 'string' }).errors.should eq({ v: 'string required' })
+        expect(validate({ v: 123456 }, { v: 'string' }).valid?).to eq false
+        expect(validate({ v: 123456 }, { v: 'string' }).errors).to eq({ v: 'string required' })
       end
 
       it 'should validate numeric' do
-        validate({ v: 1234 }, { v: 'numeric' }).valid?.should be_true
-        validate({ v: '12' }, { v: 'numeric' }).valid?.should be_false
+        expect(validate({ v: 1234 }, { v: 'numeric' }).valid?).to eq true
+        expect(validate({ v: '12' }, { v: 'numeric' }).valid?).to eq false
       end
 
       it 'should validate array' do
-        validate({ v: [ 1,2,3 ] }, { v: 'array' }).valid?.should be_true
-        validate({ v: ' 1,2,3 ' }, { v: 'array' }).valid?.should be_false
+        expect(validate({ v: [ 1,2,3 ] }, { v: 'array' }).valid?).to eq true
+        expect(validate({ v: ' 1,2,3 ' }, { v: 'array' }).valid?).to eq false
       end
 
       it 'should validate time' do
-        validate({ v: Time.now                    }, { v: 'time' }).valid?.should be_true
-        validate({ v: '2013-04-12 13:18:05 +0930' }, { v: 'time' }).valid?.should be_false
+        expect(validate({ v: Time.now                    }, { v: 'time' }).valid?).to eq true
+        expect(validate({ v: '2013-04-12 13:18:05 +0930' }, { v: 'time' }).valid?).to eq false
       end
     end
 
@@ -110,32 +110,32 @@ describe HashValidator do
 
         it 'should validate an empty hash' do
           v = validate(empty_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should validate a simple hash' do
           v = validate(simple_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should validate a simple hash 2' do
           v = validate(invalid_simple_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should validate a complex hash' do
           v = validate(complex_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should validate a complex hash 2' do
           v = validate(invalid_complex_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
       end
 
@@ -144,32 +144,32 @@ describe HashValidator do
 
         it 'should not validate an empty hash (stating missing with required)' do
           v = validate(empty_hash, validations)
-          v.valid?.should be_false
-          v.errors.should eq({ foo: 'numeric required', bar: 'string required' })
+          expect(v.valid?).to eq false
+          expect(v.errors).to eq({ foo: 'numeric required', bar: 'string required' })
         end
 
         it 'should validate a simple hash' do
           v = validate(simple_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should not validate a simple hash 2' do
           v = validate(invalid_simple_hash, validations)
-          v.valid?.should be_false
-          v.errors.should eq({ bar: 'string required' })
+          expect(v.valid?).to eq false
+          expect(v.errors).to eq({ bar: 'string required' })
         end
 
         it 'should validate a complex hash' do
           v = validate(complex_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should not validate a complex hash 2' do
           v = validate(invalid_complex_hash, validations)
-          v.valid?.should be_false
-          v.errors.should eq({ bar: 'string required' })
+          expect(v.valid?).to eq false
+          expect(v.errors).to eq({ bar: 'string required' })
         end
       end
 
@@ -178,14 +178,14 @@ describe HashValidator do
 
         it 'should validate a complex hash' do
           v = validate(complex_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should not validate a complex hash 2' do
           v = validate(invalid_complex_hash, validations)
-          v.valid?.should be_false
-          v.errors.should eq({ bar: 'string required', user: { age: 'is required', likes: 'array required' } })
+          expect(v.valid?).to eq false
+          expect(v.errors).to eq({ bar: 'string required', user: { age: 'is required', likes: 'array required' } })
         end
       end
 
@@ -194,14 +194,14 @@ describe HashValidator do
 
         it 'should validate a complex hash' do
           v = validate(complex_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should not validate a complex hash 2' do
           v = validate(invalid_complex_hash, validations)
-          v.valid?.should be_false
-          v.errors.should eq({ bar: 'string required' })
+          expect(v.valid?).to eq false
+          expect(v.errors).to eq({ bar: 'string required' })
         end
       end
 
@@ -210,14 +210,14 @@ describe HashValidator do
 
         it 'should validate a complex hash' do
           v = validate(complex_hash, validations)
-          v.valid?.should be_true
-          v.errors.should be_empty
+          expect(v.valid?).to eq true
+          expect(v.errors).to be_empty
         end
 
         it 'should not validate a complex hash 2' do
           v = validate(invalid_complex_hash, validations)
-          v.valid?.should be_false
-          v.errors.should eq({ bar: 'string required', user: { likes: 'enumerable required' } })
+          expect(v.valid?).to eq false
+          expect(v.errors).to eq({ bar: 'string required', user: { likes: 'enumerable required' } })
         end
       end
     end

--- a/spec/hash_validator_spec.rb
+++ b/spec/hash_validator_spec.rb
@@ -75,35 +75,35 @@ describe HashValidator do
       let(:empty_hash) {{}}
 
       let(:simple_hash) {{
-        foo: 1,
-        bar: 'baz'
-      }}
+          foo: 1,
+          bar: 'baz'
+        }}
 
       let(:invalid_simple_hash) {{
-        foo: 1,
-        bar: 2
-      }}
+          foo: 1,
+          bar: 2
+        }}
 
       let(:complex_hash) {{
-        foo: 1,
-        bar: 'baz',
-        user: {
-          first_name: 'James',
-          last_name:  'Brooks',
-          age:        27,
-          likes:      [ 'Ruby', 'Kendo', 'Board Games' ]
-        }
-      }}
+          foo: 1,
+          bar: 'baz',
+          user: {
+            first_name: 'James',
+            last_name:  'Brooks',
+            age:        27,
+            likes:      [ 'Ruby', 'Kendo', 'Board Games' ]
+          }
+        }}
 
       let(:invalid_complex_hash) {{
-        foo: 1,
-        bar: 2,
-        user: {
-          first_name: 'James',
-          last_name:  'Brooks',
-          likes:      'Ruby, Kendo, Board Games'
-        }
-      }}
+          foo: 1,
+          bar: 2,
+          user: {
+            first_name: 'James',
+            last_name:  'Brooks',
+            likes:      'Ruby, Kendo, Board Games'
+          }
+        }}
 
       describe 'no validations' do
         let(:validations) {{}}
@@ -222,4 +222,40 @@ describe HashValidator do
       end
     end
   end
+end
+
+describe 'Strict Validation' do
+  let(:simple_hash) { { foo: 'bar', bar: 'foo' } }
+  
+  let(:complex_hash) {{
+      foo: 1,
+      user: {
+        first_name: 'James',
+        last_name:  'Brooks',
+        age:        27,
+        likes:      [ 'Ruby', 'Kendo', 'Board Games' ]
+      }
+    }}
+  
+  let(:validations) { { foo: 'string' } }
+  
+  let(:complex_validations) {{
+      foo: 'integer',
+      user: {
+        first_name: 'string', age: 'integer'
+      }
+    }}
+  
+  it 'reports which keys are not expected for a simple hash' do
+    v = validate(simple_hash, validations, true)
+    expect(v.valid?).to eq false
+    expect(v.errors).to eq({ bar: 'key not expected' })
+  end
+  
+  it 'reports which keys are not expected for a complex hash' do
+    v = validate(complex_hash, complex_validations, true)
+    expect(v.valid?).to eq false
+    expect(v.errors).to eq(user: { last_name: 'key not expected', likes: 'key not expected' })
+  end
+  
 end

--- a/spec/hash_validator_spec_helper.rb
+++ b/spec/hash_validator_spec_helper.rb
@@ -1,5 +1,5 @@
 module HashValidatorSpecHelper
-  def validate(hash, validations)
-    HashValidator.validate(hash, validations)
+  def validate(hash, validations, strict = false)
+    HashValidator.validate(hash, validations, strict)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,6 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'
-
+  
   config.include HashValidatorSpecHelper
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,15 +2,12 @@ require 'coveralls'
 Coveralls.wear!
 
 require 'rubygems'
-require 'bundler/setup'
 require 'hash_validator'
 require 'hash_validator_spec_helper'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-
   config.order = 'random'
 
   config.include HashValidatorSpecHelper

--- a/spec/validators/boolean_spec.rb
+++ b/spec/validators/boolean_spec.rb
@@ -6,13 +6,13 @@ describe HashValidator::Validator::Base do
 
   describe '#should_validate?' do
     it 'should validate the name "boolean"' do
-      validator.should_validate?('boolean').should be_true
+      expect(validator.should_validate?('boolean')).to eq true
     end
 
     it 'should not validate other names' do
-      validator.should_validate?('string').should be_false
-      validator.should_validate?('array').should  be_false
-      validator.should_validate?(nil).should      be_false
+      expect(validator.should_validate?('string')).to eq false
+      expect(validator.should_validate?('array')).to eq false
+      expect(validator.should_validate?(nil)).to eq false
     end
   end
 
@@ -20,27 +20,27 @@ describe HashValidator::Validator::Base do
     it 'should validate a true boolean with true' do
       validator.validate(:key, true, {}, errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should validate a false boolean with true' do
       validator.validate(:key, false, {}, errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should validate a nil with false' do
       validator.validate(:key, nil, {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'boolean required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'boolean required' })
     end
 
     it 'should validate a number with false' do
       validator.validate(:key, 123, {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'boolean required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'boolean required' })
     end
   end
 end

--- a/spec/validators/email_spec.rb
+++ b/spec/validators/email_spec.rb
@@ -6,13 +6,13 @@ describe HashValidator::Validator::Base do
 
   describe '#should_validate?' do
     it 'should validate the name "email"' do
-      validator.should_validate?('email').should be_true
+      expect(validator.should_validate?('email')).to eq true
     end
 
     it 'should not validate other names' do
-      validator.should_validate?('string').should be_false
-      validator.should_validate?('array').should  be_false
-      validator.should_validate?(nil).should      be_false
+      expect(validator.should_validate?('string')).to eq false
+      expect(validator.should_validate?('array')).to eq false
+      expect(validator.should_validate?(nil)).to eq false
     end
   end
 
@@ -20,21 +20,21 @@ describe HashValidator::Validator::Base do
     it 'should validate an email with true' do
       validator.validate(:key, "johndoe@gmail.com", {}, errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should validate a string without an @ symbol with false' do
       validator.validate(:key, 'test', {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'is not a valid email' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'is not a valid email' })
     end
 
     it 'should validate a number with false' do
       validator.validate(:key, 123, {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'is not a valid email' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'is not a valid email' })
     end
   end
 end

--- a/spec/validators/in_enumerable_spec.rb
+++ b/spec/validators/in_enumerable_spec.rb
@@ -20,19 +20,19 @@ describe 'Enumerable validator' do
       let(:validations) {{ fruit: [ 'apple', 'banana', 'carrot' ] }}
 
       it 'should validate true if the value is present' do
-        validate({ fruit: 'apple' }, validations).valid?.should be_true
+        expect(validate({ fruit: 'apple' }, validations).valid?).to eq true
       end
 
       it 'should validate false if the value is not present' do
-        validate({ fruit: 'pear' }, validations).valid?.should be_false
+        expect(validate({ fruit: 'pear' }, validations).valid?).to eq false
       end
 
       it 'should validate false if the key is not present' do
-        validate({ something: 'apple' }, validations).valid?.should be_false
+        expect(validate({ something: 'apple' }, validations).valid?).to eq false
       end
 
       it 'should provide an appropriate error message is the value is not present' do
-        validate({ fruit: 'pear' }, validations).errors.should eq({ fruit: 'value from list required' })
+        expect(validate({ fruit: 'pear' }, validations).errors).to eq({ fruit: 'value from list required' })
       end
     end
 
@@ -40,10 +40,10 @@ describe 'Enumerable validator' do
       let(:validations) {{ number: 1..10 }}
 
       it 'should validate true if the value is present' do
-        validate({ number: 5 }, validations).valid?.should be_true
+        expect(validate({ number: 5 }, validations).valid?).to eq true
       end
       it 'should validate false if the value is not present' do
-        validate({ number: 15 }, validations).valid?.should be_false
+        expect(validate({ number: 15 }, validations).valid?).to eq false
       end
     end
 
@@ -51,10 +51,10 @@ describe 'Enumerable validator' do
       let(:validations) {{ number: 1..Float::INFINITY }}
 
       it 'should validate true if the value is present' do
-        validate({ number: 5 }, validations).valid?.should be_true
+        expect(validate({ number: 5 }, validations).valid?).to eq true
       end
       it 'should validate false if the value is not present' do
-        validate({ number: -5 }, validations).valid?.should be_false
+        expect(validate({ number: -5 }, validations).valid?).to eq false
       end
     end
 
@@ -62,7 +62,7 @@ describe 'Enumerable validator' do
       let(:validations) {{ fruit: [ nil, :apple, :banana ] }}
 
       it 'should validate true if a nil value is present' do
-        validate({ fruit: nil }, validations).valid?.should be_true
+        expect(validate({ fruit: nil }, validations).valid?).to eq true
       end
     end
   end

--- a/spec/validators/lambda_spec.rb
+++ b/spec/validators/lambda_spec.rb
@@ -29,11 +29,11 @@ describe 'Functional validator' do
     let(:validations) {{ number: lambda { |n| n.odd? } }}
 
     it 'should validate true when the number is odd' do
-      validate({ number: 1 }, validations).valid?.should be_true
+      expect(validate({ number: 1 }, validations).valid?).to eq true
     end
 
     it 'should validate false when the number is even' do
-      validate({ number: 2 }, validations).valid?.should be_false
+      expect(validate({ number: 2 }, validations).valid?).to eq false
     end
   end
 
@@ -41,7 +41,7 @@ describe 'Functional validator' do
     let(:validations) {{ number: lambda { |n| n.odd? } }}
 
     it 'should validate false when an exception occurs within the lambda' do
-      validate({ number: '2' }, validations).valid?.should be_false
+      expect(validate({ number: '2' }, validations).valid?).to eq false
     end
   end
 end

--- a/spec/validators/many_spec.rb
+++ b/spec/validators/many_spec.rb
@@ -10,13 +10,13 @@ describe HashValidator::Validator::Base do
 
   describe '#should_validate?' do
     it 'should validate an Many validation' do
-      validator.should_validate?(many('string')).should be_true
+      expect(validator.should_validate?(many('string'))).to eq true
     end
 
     it 'should not validate other things' do
-      validator.should_validate?('string').should be_false
-      validator.should_validate?('array').should  be_false
-      validator.should_validate?(nil).should      be_false
+      expect(validator.should_validate?('string')).to eq false
+      expect(validator.should_validate?('array')).to eq false
+      expect(validator.should_validate?(nil)).to eq false
     end
   end
 
@@ -24,37 +24,37 @@ describe HashValidator::Validator::Base do
     it 'should accept an empty array' do
       validator.validate(:key, [], many('string'), errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should accept an array of matching elements' do
       validator.validate(:key, ['a', 'b'], many('string'), errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should not accept an array including a non-matching element' do
       validator.validate(:key, ['a', 2], many('string'), errors)
 
-      errors.should eq({ key: [nil, 'string required'] })
+      expect(errors).to eq({ key: [nil, 'string required'] })
     end
 
     it 'should accept an array of matching hashes' do
       validator.validate(:key, [{v: 'a'}, {v: 'b'}], many({v: 'string'}), errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should not accept an array including a non-matching element' do
       validator.validate(:key, [{v: 'a'}, {v: 2}], many({v: 'string'}), errors)
 
-      errors.should eq({ key: [nil, {v: 'string required'}] })
+      expect(errors).to eq({ key: [nil, {v: 'string required'}] })
     end
 
     it 'should not accept a non-enumerable' do
       validator.validate(:key, 'a', many({v: 'string'}), errors)
 
-      errors.should eq({ key: 'enumerable required' })
+      expect(errors).to eq({ key: 'enumerable required' })
     end
   end
 end

--- a/spec/validators/optional_spec.rb
+++ b/spec/validators/optional_spec.rb
@@ -10,13 +10,13 @@ describe HashValidator::Validator::Base do
 
   describe '#should_validate?' do
     it 'should validate an Optional validation' do
-      validator.should_validate?(optional('string')).should be_true
+      expect(validator.should_validate?(optional('string'))).to eq true
     end
 
     it 'should not validate other things' do
-      validator.should_validate?('string').should be_false
-      validator.should_validate?('array').should  be_false
-      validator.should_validate?(nil).should      be_false
+      expect(validator.should_validate?('string')).to eq false
+      expect(validator.should_validate?('array')).to eq false
+      expect(validator.should_validate?(nil)).to eq false
     end
   end
 
@@ -24,33 +24,33 @@ describe HashValidator::Validator::Base do
     it 'should accept a missing value' do
       validator.validate(:key, nil, optional('string'), errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should accept a present, matching value' do
       validator.validate(:key, 'foo', optional('string'), errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should reject a present, non-matching value' do
       validator.validate(:key, 123, optional('string'), errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'string required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'string required' })
     end
 
     it 'should accept a present, matching hash' do
       validator.validate(:key, {v: 'foo'}, optional({v: 'string'}), errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should reject a present, non-matching hash' do
       validator.validate(:key, {}, optional({v: 'string'}), errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: {v: 'string required'} })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: {v: 'string required'} })
     end
   end
 end

--- a/spec/validators/presence_spec.rb
+++ b/spec/validators/presence_spec.rb
@@ -6,13 +6,13 @@ describe HashValidator::Validator::Base do
 
   describe '#should_validate?' do
     it 'should validate the name "required"' do
-      validator.should_validate?('required').should be_true
+      expect(validator.should_validate?('required')).to eq true
     end
 
     it 'should not validate other names' do
-      validator.should_validate?('string').should be_false
-      validator.should_validate?('array').should  be_false
-      validator.should_validate?(nil).should      be_false
+      expect(validator.should_validate?('string')).to eq false
+      expect(validator.should_validate?('array')).to eq false
+      expect(validator.should_validate?(nil)).to eq false
     end
   end
 
@@ -20,26 +20,26 @@ describe HashValidator::Validator::Base do
     it 'should validate a string with true' do
       validator.validate(:key, 'test', {}, errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should validate a number with true' do
       validator.validate(:key, 123, {}, errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should validate a time with true' do
       validator.validate(:key, Time.now, {}, errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'should validate nil with false' do
       validator.validate(:key, nil, {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'is required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'is required' })
     end
   end
 end

--- a/spec/validators/simple_spec.rb
+++ b/spec/validators/simple_spec.rb
@@ -31,7 +31,7 @@ describe HashValidator::Validator::SimpleValidator do
       it "validates the string '#{value}'" do
         short_string_validator.validate(:key, value, {}, errors)
 
-        errors.should be_empty
+        expect(errors).to be_empty
       end
     end
 
@@ -39,7 +39,7 @@ describe HashValidator::Validator::SimpleValidator do
       it "does not validate bad value '#{value}'" do
         short_string_validator.validate(:key, value, {}, errors)
 
-        errors.should eq({ key: 'short_string required' })
+        expect(errors).to eq({ key: 'short_string required' })
       end
     end
   end

--- a/spec/validators/simple_types_spec.rb
+++ b/spec/validators/simple_types_spec.rb
@@ -59,8 +59,8 @@ describe 'Simple validator types' do
         it "validates '#{value}' successful" do
           validator = HashValidator.validate({ v: value }, { v: type.to_s })
 
-          validator.valid?.should be_true
-          validator.errors.should be_empty
+          expect(validator.valid?).to eq true
+          expect(validator.errors).to be_empty
         end
       end
 
@@ -68,8 +68,8 @@ describe 'Simple validator types' do
         it "validates '#{value}' with failure" do
           validator = HashValidator.validate({ v: value }, { v: type.to_s })
 
-          validator.valid?.should be_false
-          validator.errors.should eq({ v: "#{type} required" })
+          expect(validator.valid?).to eq false
+          expect(validator.errors).to eq({ v: "#{type} required" })
         end
       end
     end

--- a/spec/validators/user_defined_spec.rb
+++ b/spec/validators/user_defined_spec.rb
@@ -25,13 +25,13 @@ describe 'User-defined validator' do
 
   describe '#should_validate?' do
     it 'validates the name "odd"' do
-      validator.should_validate?('odd').should be_true
+      expect(validator.should_validate?('odd')).to eq true
     end
 
     it 'does not validate other names' do
-      validator.should_validate?('string').should be_false
-      validator.should_validate?('array').should  be_false
-      validator.should_validate?(nil).should      be_false
+      expect(validator.should_validate?('string')).to eq false
+      expect(validator.should_validate?('array')).to eq false
+      expect(validator.should_validate?(nil)).to eq false
     end
   end
 
@@ -39,35 +39,35 @@ describe 'User-defined validator' do
     it 'validates odd integers with true' do
       validator.validate(:key, 1, {}, errors)
 
-      errors.should be_empty
+      expect(errors).to be_empty
     end
 
     it 'validates even integers with errrors' do
       validator.validate(:key, 2, {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'odd required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'odd required' })
     end
 
     it 'validates even floats with errrors' do
       validator.validate(:key, 2.0, {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'odd required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'odd required' })
     end
 
     it 'validates odd floats with errrors' do
       validator.validate(:key, 1.0, {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'odd required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'odd required' })
     end
 
     it 'validates an odd integer string with errrors' do
       validator.validate(:key, '1', {}, errors)
 
-      errors.should_not be_empty
-      errors.should eq({ key: 'odd required' })
+      expect(errors).not_to be_empty
+      expect(errors).to eq({ key: 'odd required' })
     end
   end
 
@@ -75,21 +75,21 @@ describe 'User-defined validator' do
     before { HashValidator.append_validator(validator) rescue nil }  # rescue to prevent: validators need to have unique names
 
     it 'can be looked up using #validator_for' do
-      HashValidator.validator_for('odd').should be_a_kind_of(HashValidator::Validator::OddValidator)
+      expect(HashValidator.validator_for('odd')).to be_a_kind_of(HashValidator::Validator::OddValidator)
     end
 
     it 'can be used in validations - test 1' do
       validator = HashValidator.validate({ age: 27 }, { age: 'odd' })
 
-      validator.valid?.should be_true
-      validator.errors.should be_empty
+      expect(validator.valid?).to eq true
+      expect(validator.errors).to be_empty
     end
 
     it 'can be used in validations - test 2' do
       validator = HashValidator.validate({ age: 40 }, { age: 'odd' })
 
-      validator.valid?.should be_false
-      validator.errors.should eq({ age: 'odd required' })
+      expect(validator.valid?).to eq false
+      expect(validator.errors).to eq({ age: 'odd required' })
     end
   end
 end


### PR DESCRIPTION
So I was using hash-validator in a API test project and I was in need to be warned of changes in some hash structures. Most of the changes were that some keys were added to the hash, and then I would need to add the validation to it in my endpoint.
Then I thougth about that and came up with "strict validation".

I added a optional parameter to "HashValidator.validate" method to turn on this feature.
You set up the expected hash structure with the validations you need. Then when you call "HashValidator.validate(hash, validations, true)" it will perform strict validation, and output the not expected keys (keys that are not in the "validations" hash) to the "errors".

I made two commits. One is to implement the strict validation with the test cases for it. The other is an update to the RSpec syntax. Almost all tests were failing here because of the old syntax.

Please let me know if I am missing something and I will fix it.