### PR TITLE
Make optional validator work with FalseClass

### DIFF
--- a/lib/hash_validator/validators/optional_validator.rb
+++ b/lib/hash_validator/validators/optional_validator.rb
@@ -10,7 +10,7 @@ module HashValidator
       end
 
       def validate(key, value, validations, errors)
-        if value
+        unless value.nil?
           ::HashValidator.validator_for(validations.validation).validate(key, value, validations.validation, errors)
           errors.delete(key) if errors[key].respond_to?(:empty?) && errors[key].empty?
         end


### PR DESCRIPTION
The `if value` syntax was considering the truthiness of the value, making something like `value => optional('string')` pass if the value is `false`

